### PR TITLE
Open date pickers in control month without defaulting values

### DIFF
--- a/views/control_interno_views.xml
+++ b/views/control_interno_views.xml
@@ -9,12 +9,12 @@
             <tree string="Costos y Gastos" editable="bottom" default_order="fecha_comprobante asc">
                 <field name="factura_xml_id" string="Factura XML"  optional="show"/>
                 <field name="orden_compra_id" />
-                <field name="fecha_pago"/>
+                <field name="fecha_pago" options="{'datepicker': {'defaultDate': context.get('control_month_first_day')}}"/>
                 <field name="tipo_pago"  optional="show"/>
                 <field name="tipo_comprobante"  optional="show"/>
                 <field name="folio_fiscal"  optional="show"/>
                 <field name="no_comprobante" optional="show"/>
-                <field name="fecha_comprobante" optional="show"/>
+                <field name="fecha_comprobante" optional="show" options="{'datepicker': {'defaultDate': context.get('control_month_first_day')}}"/>
                 <field name="concepto" optional="show"/>
                 <field name="proveedor_text" optional="show"/>
                 <field name="tax_id" optional="show"/>
@@ -55,12 +55,12 @@
                     <group>
                         <field name="factura_xml_id" string="Factura XML"/>
                         <field name="orden_compra_id"/>
-                        <field name="fecha_pago"/>
+                        <field name="fecha_pago" options="{'datepicker': {'defaultDate': context.get('control_month_first_day')}}"/>
                         <field name="tipo_pago"/>
                         <field name="tipo_comprobante"/>
                         <field name="folio_fiscal"/>
                         <field name="no_comprobante"/>
-                        <field name="fecha_comprobante"/>
+                        <field name="fecha_comprobante" options="{'datepicker': {'defaultDate': context.get('control_month_first_day')}}"/>
                         <field name="concepto"/>
                         <field name="proveedor_text"/>
                         <field name="proveedor_id" hidden="true"/>
@@ -111,7 +111,7 @@
                     </group>
                     <notebook>
                         <page string="Costos y Gastos">
-                            <field name="costos_gastos_ids" context="{'default_control_interno_id': id}" mode="tree,form">
+                            <field name="costos_gastos_ids" context="{'default_control_interno_id': id, 'control_month_first_day': (mes and mes.strftime('%Y-%m-01')) or False}" mode="tree,form">
                                 <views>
                                     <view ref="view_costos_gastos_line_tree" type="tree"/>
                                     <view ref="view_costos_gastos_line_form" type="form"/>


### PR DESCRIPTION
## Summary
- remove the custom default_get override so new cost lines keep payment and invoice dates empty
- configure the control interno views with context and datepicker options so the calendar opens on the control month by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfafee4cc83308139103d18a972d9