### PR TITLE
Set petty cash payment date from voucher date

### DIFF
--- a/models/costos_gastos_line.py
+++ b/models/costos_gastos_line.py
@@ -79,6 +79,16 @@ class CostosGastosLine(models.Model):
                 defaults['fecha_comprobante'] = first_day
         return defaults"""
 
+    @api.onchange('tipo_pago', 'fecha_comprobante')
+    def _onchange_tipo_pago(self):
+        """Set payment date from voucher date when using petty cash."""
+        if (
+            self.tipo_pago == 'caja_chica'
+            and not self.fecha_pago
+            and self.fecha_comprobante
+        ):
+            self.fecha_pago = self.fecha_comprobante
+
     @api.depends('orden_compra_id')
     def _compute_orden_compra_changed(self):
         for record in self:


### PR DESCRIPTION
## Summary
- add onchange handler for petty cash payments to copy the voucher date to the payment date when empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc546419b88330a594ee4d07c9a336