### PR TITLE
Set comprobante type from XML country

### DIFF
--- a/models/control_interno_mensual.py
+++ b/models/control_interno_mensual.py
@@ -45,6 +45,12 @@ class ControlInternoMensual(models.Model):
             if existing_line:
                 # Skip creating a duplicate line
                 continue
+            tipo_comprobante = False
+            if factura.pais_id and factura.pais_id.code:
+                if factura.pais_id.code.upper() == 'MX':
+                    tipo_comprobante = 'factura_nacional'
+                else:
+                    tipo_comprobante = 'factura_extranjera'
             self.env['costos.gastos.line'].create({
                 'control_interno_id': self.id,
                 'factura_xml_id': factura.id,
@@ -62,6 +68,7 @@ class ControlInternoMensual(models.Model):
                 'folio_fiscal': factura.uuid,
                 'no_comprobante': factura.folio,
                 'concepto': factura.concepto,
+                'tipo_comprobante': tipo_comprobante,
             })
 
     def action_export_csv(self):

--- a/models/costos_gastos_line.py
+++ b/models/costos_gastos_line.py
@@ -218,6 +218,11 @@ class CostosGastosLine(models.Model):
                 self.no_comprobante = factura.folio
             if not self.concepto:
                 self.concepto = factura.concepto
+            if not self.tipo_comprobante and factura.pais_id and factura.pais_id.code:
+                if factura.pais_id.code.upper() == 'MX':
+                    self.tipo_comprobante = 'factura_nacional'
+                else:
+                    self.tipo_comprobante = 'factura_extranjera'
             # If 'orden_compra_id' is empty, set it from 'factura.xml'
             if not self.orden_compra_id and factura.ordenes_compra_ids:
                 self.orden_compra_id = factura.ordenes_compra_ids[0]


### PR DESCRIPTION
## Summary
- set the comprobante type on control interno lines generated from monthly XML invoices according to the supplier country
- mirror the same behavior when a factura XML is manually selected on a cost line

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc5a074bf88330b1628dc71627c3e2