### PR TITLE
Importar forma de pago y propagarla al control interno

### DIFF
--- a/models/control_interno_mensual.py
+++ b/models/control_interno_mensual.py
@@ -2,11 +2,11 @@
 
 from odoo import models, fields, api
 from odoo.exceptions import UserError
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import csv
 import base64
 from io import StringIO
+
 
 
 class ControlInternoMensual(models.Model):
@@ -51,6 +51,7 @@ class ControlInternoMensual(models.Model):
                     tipo_comprobante = 'factura_nacional'
                 else:
                     tipo_comprobante = 'factura_extranjera'
+            tipo_pago = factura.get_tipo_pago_control_interno()
             self.env['costos.gastos.line'].create({
                 'control_interno_id': self.id,
                 'factura_xml_id': factura.id,
@@ -69,6 +70,7 @@ class ControlInternoMensual(models.Model):
                 'no_comprobante': factura.folio,
                 'concepto': factura.concepto,
                 'tipo_comprobante': tipo_comprobante,
+                'tipo_pago': tipo_pago,
             })
 
     def action_export_csv(self):

--- a/models/costos_gastos_line.py
+++ b/models/costos_gastos_line.py
@@ -190,6 +190,10 @@ class CostosGastosLine(models.Model):
         if self.factura_xml_id:
             factura = self.factura_xml_id
             # Fill in fields if they are empty
+            if not self.tipo_pago:
+                tipo_pago = factura.get_tipo_pago_control_interno()
+                if tipo_pago:
+                    self.tipo_pago = tipo_pago
             if not self.folio_fiscal:
                 self.folio_fiscal = factura.uuid
             if not self.fecha_comprobante:

--- a/models/factura_xml_wizard.py
+++ b/models/factura_xml_wizard.py
@@ -59,6 +59,7 @@ class FacturaXMLWizard(models.TransientModel):
         descuento = float(root.attrib.get('Descuento', '0'))
         moneda = root.attrib.get('Moneda', 'MXN')
         tipo_cambio = float(root.attrib.get('TipoCambio', '1'))
+        forma_pago = root.attrib.get('FormaPago', '')
 
         impuestos = root.find('cfdi:Impuestos', ns)
         iva = 0.0
@@ -97,4 +98,5 @@ class FacturaXMLWizard(models.TransientModel):
             'iva': iva,
             'total': total,
             'concepto': descripcion_concatenada,
+            'forma_pago': forma_pago,
         })


### PR DESCRIPTION
## Summary
- almacenar la forma de pago desde los CFDI importados en los registros de factura XML
- exponer una utilidad para traducir la forma de pago del CFDI a los tipos de pago del control interno
- rellenar automáticamente el tipo de pago en líneas de control interno tanto al cargar facturas del mes como al seleccionar manualmente una factura

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc5cdda5e08330b524aaadbc537809