### PR TITLE
Improve bank reconciliation with secondary matching and fecha_pago sync

### DIFF
--- a/models/conciliacion_manual_wizard.py
+++ b/models/conciliacion_manual_wizard.py
@@ -84,6 +84,11 @@ class ConciliacionManualWizard(models.TransientModel):
                 if po_ids:
                     vals['purchase_order_ids'] = [(6, 0, po_ids)]
                 rec.movimiento_id.sudo().write(vals)
+                # Set fecha_pago on lines that don't have one
+                if rec.movimiento_id.fecha:
+                    for line in lines:
+                        if not line.fecha_pago:
+                            line.fecha_pago = rec.movimiento_id.fecha
 
     def action_confirmar(self):
         """Ensure save and close the dialog."""

--- a/models/estado_cuenta_bancario.py
+++ b/models/estado_cuenta_bancario.py
@@ -141,6 +141,35 @@ class EstadoCuentaBancario(models.Model):
             else:
                 skipped += 1
 
+        # Second pass: match movements without fecha_pago by same month + amount
+        for mov in self.movimiento_ids:
+            if mov.costos_gastos_line_ids:
+                continue  # already matched (including from first pass)
+
+            monto = mov.retiro if mov.retiro > 0 else mov.deposito
+            if not monto or not mov.fecha:
+                continue
+
+            domain = [
+                ('fecha_pago', '=', False),
+                ('mes', '=', self.mes),
+                ('total', '>=', monto - 0.01),
+                ('total', '<=', monto + 0.01),
+            ]
+            candidates = self.env['costos.gastos.line'].search(domain)
+            candidates = candidates.filtered(
+                lambda c: not c.movimiento_bancario_ids
+            )
+
+            if len(candidates) == 1:
+                mov.costos_gastos_line_ids = [(4, candidates.id)]
+                candidates.fecha_pago = mov.fecha
+                if candidates.orden_compra_id:
+                    mov.purchase_order_ids = [(4, candidates.orden_compra_id.id)]
+                matched += 1
+            else:
+                skipped += 1
+
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',


### PR DESCRIPTION
## Summary
Enhanced the automatic bank reconciliation process to include a secondary matching pass and ensure payment dates are properly synchronized during manual reconciliation.

## Key Changes

- **Secondary reconciliation pass**: Added a second matching algorithm in `action_auto_conciliar()` that matches unmatched bank movements with cost/expense lines based on:
  - Same month (mes)
  - Matching amount (within 0.01 tolerance)
  - Lines without an assigned payment date (fecha_pago)
  - Lines not yet linked to any bank movement
  - Only matches when exactly one candidate is found to avoid ambiguity

- **Payment date synchronization**: Updated `_sync_to_movimiento()` in the manual reconciliation wizard to automatically set `fecha_pago` on cost/expense lines that don't have one, using the bank movement's date

- **Purchase order linking**: Secondary pass also links associated purchase orders to the bank movement when a match is found

## Implementation Details

- The secondary pass runs after the initial matching logic and only processes movements that haven't been matched yet
- Matching uses a tolerance of ±0.01 to account for rounding differences
- The `fecha_pago` sync in manual reconciliation only updates lines that don't already have a payment date set, preserving existing values
- Both changes improve reconciliation coverage and data consistency without requiring manual intervention

https://claude.ai/code/session_011s5FEt2YsS3wPbWXEQKPts